### PR TITLE
The BootstrapAwareContentAreaRenderer always loaded the DisplayModes from the DDS 

### DIFF
--- a/BootstrapAwareContentAreaRenderer.cs
+++ b/BootstrapAwareContentAreaRenderer.cs
@@ -6,6 +6,7 @@ using System.Web.Mvc;
 using EPiServer;
 using EPiServer.Core;
 using EPiServer.Data.Dynamic;
+using EPiServer.ServiceLocation;
 using EPiServer.Web.Mvc.Html;
 using HtmlAgilityPack;
 
@@ -117,13 +118,14 @@ namespace EPiBootstrapArea
 
         private static void ReadRegisteredDisplayModes()
         {
+            var displayModeFallbackProvider = ServiceLocator.Current.GetInstance<IDisplayModeFallbackProvider>();
+
             if (_fallbackCached)
             {
                 return;
             }
 
-            var store = typeof(DisplayModeFallback).GetStore();
-            _fallbacks = store.LoadAll<DisplayModeFallback>().ToList();
+            _fallbacks = displayModeFallbackProvider.GetAll();
             _fallbackCached = true;
         }
     }

--- a/EPiBootstrapArea.csproj
+++ b/EPiBootstrapArea.csproj
@@ -37,7 +37,7 @@
   <ItemGroup>
     <Reference Include="Castle.Core, Version=3.2.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <Private>True</Private>
-      <HintPath>packages\Castle.Core.3.2.2\lib\net40\Castle.Core.dll</HintPath>
+      <HintPath>packages\Castle.Core.3.2.2\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Windsor, Version=3.2.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <Private>True</Private>


### PR DESCRIPTION
The BootstrapAwareContentAreaRenderer always loaded the DisplayModes from the DDS regardless what provider was being used witch resulted in it not finding the displaymodes in the DefaultProvider.

I changed it so that it instead uses the IDisplayModeFallbackProvider to load Displaymodes.