### PR TITLE
Trim whitespaces when checking if block content is empty

### DIFF
--- a/BootstrapAwareContentAreaRenderer.cs
+++ b/BootstrapAwareContentAreaRenderer.cs
@@ -158,7 +158,7 @@ namespace EPiBootstrapArea
                     // pass node to callback for some fancy modifications (if any)
                     _elementStartTagRenderCallback?.Invoke(blockContentNode, contentAreaItem, content);
 
-                    if (!string.IsNullOrEmpty(blockContentNode.InnerHtml))
+                    if (!string.IsNullOrEmpty(blockContentNode.InnerHtml.Trim(null)))
                     {
                         var renderItemContainer = GetFlagValueFromViewData(htmlHelper, "hasitemcontainer");
 


### PR DESCRIPTION
Currently blocks that don't render anything but whitespaces (usually endlines from cshtml) are still rendered in the grid. An easy fix is to trim block html when checking if it's empty.